### PR TITLE
feat: Updating storybook color palette and token generators

### DIFF
--- a/packages/lib/theme-utils/src/utils/tokens/semanticColorTokenUtils.js
+++ b/packages/lib/theme-utils/src/utils/tokens/semanticColorTokenUtils.js
@@ -97,14 +97,14 @@ export const genSemanticCanvasColorsTokens = ({
 
     return {
         [massageConstToDotNotation(SEMANTIC_COLOR_CANVAS)]: isDarkMode
-            ? NEUTRAL_COLORS['core.color.neutral.10']
+            ? NEUTRAL_COLORS['core.color.neutral.5']
             : NEUTRAL_COLORS[
                   massageConstToDotNotation(
                       CORE_NEUTRAL_COLOR_TOKEN_NAMES.CORE_COLOR_NEUTRAL_100,
                   )
               ],
         [massageConstToDotNotation(SEMANTIC_COLOR_CANVAS_ALT)]: isDarkMode
-            ? NEUTRAL_COLORS['core.color.neutral.15']
+            ? NEUTRAL_COLORS['core.color.neutral.10']
             : NEUTRAL_COLORS['core.color.neutral.95'],
     };
 };

--- a/packages/storybook/stories/designers/working-with-color/sections/color-palette-generator/SectionPaletteChoices.jsx
+++ b/packages/storybook/stories/designers/working-with-color/sections/color-palette-generator/SectionPaletteChoices.jsx
@@ -174,19 +174,19 @@ const SectionPaletteChoices = (props) => {
                         <DynamicFormRow>
                             <ColorPaletteGenSwatch
                                 token={SEMANTIC_COLOR_AFFIRMATIVE}
-                                options={[statusColors.affirmative]}
+                                options={[statusColors.affirmative, ...colors]}
                                 onChange={handleChange}
                                 color={fieldValues[SEMANTIC_COLOR_AFFIRMATIVE]}
                             />
                             <ColorPaletteGenSwatch
                                 token={SEMANTIC_COLOR_CAUTIONARY}
-                                options={[statusColors.cautionary]}
+                                options={[statusColors.cautionary, ...colors]}
                                 onChange={handleChange}
                                 color={fieldValues[SEMANTIC_COLOR_CAUTIONARY]}
                             />
                             <ColorPaletteGenSwatch
                                 token={SEMANTIC_COLOR_ERROR}
-                                options={[statusColors.error]}
+                                options={[statusColors.error, ...colors]}
                                 onChange={handleChange}
                                 color={fieldValues[SEMANTIC_COLOR_ERROR]}
                             />

--- a/packages/storybook/stories/everyone/tokens/StoryDesignTokenGen.jsx
+++ b/packages/storybook/stories/everyone/tokens/StoryDesignTokenGen.jsx
@@ -10,6 +10,7 @@ import BadgeCompPreview from './components/design-token-gen/BadgeCompPreview';
 import BannerCompPreview from './components/design-token-gen/BannerCompPreview';
 import ButtonCompPreview from './components/design-token-gen/ButtonCompPreview';
 import CalloutCompPreview from './components/design-token-gen/CalloutCompPreview';
+import LinkCompPreview from './components/design-token-gen/LinkCompPreview';
 import {
     genTokens,
     getTokensByCategory,
@@ -163,6 +164,7 @@ const initialState = {
         constToTokenMap[SEMANTIC_COLOR_CAUTIONARY],
     calloutDangerSourceColorToken: constToTokenMap[SEMANTIC_COLOR_ERROR],
     calloutInfoSourceColorToken: constToTokenMap[SEMANTIC_COLOR_INFO],
+    linkSourceColorToken: constToTokenMap[SEMANTIC_COLOR_PRIMARY],
     isDarkMode: false,
     shouldAutoCorrectForA11y: true,
     // shouldUseMinimumAPCATextCompliance: true,
@@ -667,7 +669,20 @@ const StoryDesignTokenGen = () => {
                 baseCls={baseCls}
                 tokensData={linkTokens}
                 sectionTitle="Links"
-            />
+            >
+                <LinkCompPreview
+                    baseCls={baseCls}
+                    isDarkMode={fieldValues.isDarkMode}
+                    semanticTokens={semanticTokens}
+                    tokensData={linkTokens}
+                    dispatch={dispatch}
+                    opsProps={{
+                        label: 'Link Source Color Token',
+                        sourceTokenOps: tokenDropdownListData,
+                        value: fieldValues.linkSourceColorToken,
+                    }}
+                />
+            </SectionTokens>
             <SectionTokens
                 baseCls={baseCls}
                 tokensData={loadingTokens}

--- a/packages/storybook/stories/everyone/tokens/components/design-token-gen/LinkCompPreview.jsx
+++ b/packages/storybook/stories/everyone/tokens/components/design-token-gen/LinkCompPreview.jsx
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import { Hyperlink } from '@driponfleek/bankai-ui-navigation';
+import CompPreviewWithOps from './CompPreviewWithOps';
+import SourceTokenOps from './SourceTokenOps';
+
+const LinkCompPreview = (props) => {
+    const { baseCls, opsProps, dispatch, ...rest } = props;
+    const handleChange = (value = {}) => {
+        if (value?.id) {
+            dispatch({ linkSourceColorToken: value.id });
+        }
+    };
+    const opsVal = useMemo(
+        () =>
+            opsProps?.sourceTokenOps.find(
+                (token) => token.id === opsProps?.value,
+            ),
+        [opsProps],
+    );
+
+    return (
+        <CompPreviewWithOps
+            {...rest}
+            contextCls={`${baseCls}__link-preview`}
+            renderOps={SourceTokenOps}
+            opsProps={{ ...opsProps, onChange: handleChange, value: opsVal }}
+        >
+            <Hyperlink href="#">Link Text</Hyperlink>
+        </CompPreviewWithOps>
+    );
+};
+
+export default LinkCompPreview;

--- a/packages/storybook/stories/everyone/tokens/styles/story-design-token-gen.scss
+++ b/packages/storybook/stories/everyone/tokens/styles/story-design-token-gen.scss
@@ -48,4 +48,8 @@
             }
         }
     }
+
+    &__children-container + .bankai-sb-section {
+        margin-top: bankai-to-px($bankai-core-spacing-04-x);
+    }
 }

--- a/packages/storybook/stories/everyone/tokens/utils/designTokenGenStoryUtils.js
+++ b/packages/storybook/stories/everyone/tokens/utils/designTokenGenStoryUtils.js
@@ -47,6 +47,7 @@ export const genTokens = (fieldValues = {}) => {
         calloutCautionarySourceColorToken,
         calloutDangerSourceColorToken,
         calloutInfoSourceColorToken,
+        linkSourceColorToken,
         ...fieldVals
     } = fieldValues;
     const presets = {};
@@ -120,6 +121,9 @@ export const genTokens = (fieldValues = {}) => {
                 },
                 calloutInfo: {
                     sourceColorToken: calloutInfoSourceColorToken,
+                },
+                link: {
+                    sourceColorToken: linkSourceColorToken,
                 },
             },
         }),


### PR DESCRIPTION
* Added hyperlink component preview and ability to remap to a different source token.
* Updated status colors on the color palette generator so user can pick from other colors that might work in stead of recommended ones.
* Updated theming to pick from darker canvas colors when generating for dark mode.